### PR TITLE
Export protocol codes

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -7,25 +7,36 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+// You **MUST** register your multicodecs with
+// https://github.com/multiformats/multicodec before adding them here.
+//
+// TODO: Use a single source of truth for all multicodecs instead of
+// distributing them like this...
+const (
+	P_DNS4    = 0x0036
+	P_DNS6    = 0x0037
+	P_DNSADDR = 0x0038
+)
+
 var Dns4Protocol = ma.Protocol{
-	Code:       54,
+	Code:       P_DNS4,
 	Size:       ma.LengthPrefixedVarSize,
 	Name:       "dns4",
-	VCode:      ma.CodeToVarint(54),
+	VCode:      ma.CodeToVarint(P_DNS4),
 	Transcoder: DnsTranscoder,
 }
 var Dns6Protocol = ma.Protocol{
-	Code:       55,
+	Code:       P_DNS6,
 	Size:       ma.LengthPrefixedVarSize,
 	Name:       "dns6",
-	VCode:      ma.CodeToVarint(55),
+	VCode:      ma.CodeToVarint(P_DNS6),
 	Transcoder: DnsTranscoder,
 }
 var DnsaddrProtocol = ma.Protocol{
-	Code:       56,
+	Code:       P_DNSADDR,
 	Size:       ma.LengthPrefixedVarSize,
 	Name:       "dnsaddr",
-	VCode:      ma.CodeToVarint(56),
+	VCode:      ma.CodeToVarint(P_DNSADDR),
 	Transcoder: DnsTranscoder,
 }
 

--- a/dns.go
+++ b/dns.go
@@ -7,11 +7,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// You **MUST** register your multicodecs with
-// https://github.com/multiformats/multicodec before adding them here.
-//
-// TODO: Use a single source of truth for all multicodecs instead of
-// distributing them like this...
+// Extracted from source of truth for multicodec codes: https://github.com/multiformats/multicodec
 const (
 	P_DNS4    = 0x0036
 	P_DNS6    = 0x0037


### PR DESCRIPTION
Export the protocol codes so they can be used in `whyrusleeping/mafmt`.
I also added the 'single source of truth' comment as in `go-multiaddr`. I could not find a decision in this regard. Let me know if there is a single source of truth already, I can change the PR to reflect it.