### PR TITLE
fix handling of short records

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -174,6 +174,9 @@ func (r *Resolver) resolveDnsaddr(ctx context.Context, maddr ma.Multiaddr) ([]ma
 // XXX probably insecure
 func matchDnsaddr(maddr ma.Multiaddr, trailer []ma.Multiaddr) bool {
 	parts := ma.Split(maddr)
+	if len(trailer) > len(parts) {
+		return false
+	}
 	if ma.Join(parts[len(parts)-len(trailer):]...).Equal(ma.Join(trailer...)) {
 		return true
 	}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -104,6 +104,19 @@ func TestNonResolvable(t *testing.T) {
 	}
 }
 
+func TestLongMatch(t *testing.T) {
+	ctx := context.Background()
+	resolver := makeResolver()
+
+	res, err := resolver.Resolve(ctx, ma.StringCast("/dnsaddr/example.com/quic/quic/quic/quic"))
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 0 {
+		t.Error("expected no results")
+	}
+}
+
 func TestEmptyResult(t *testing.T) {
 	ctx := context.Background()
 	resolver := makeResolver()


### PR DESCRIPTION
If the "match" part of the multiaddr is longer than the record, don't panic.