### PR TITLE
feat: exposes backend

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -13,14 +13,16 @@ var DefaultResolver = &Resolver{Backend: net.DefaultResolver}
 
 const dnsaddrTXTPrefix = "dnsaddr="
 
-type backend interface {
+type Backend interface {
 	LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
 	LookupTXT(context.Context, string) ([]string, error)
 }
 
 type Resolver struct {
-	Backend backend
+	Backend Backend
 }
+
+var _ Backend = (*MockBackend)(nil)
 
 type MockBackend struct {
 	IP  map[string][]net.IPAddr


### PR DESCRIPTION
While impementing the [go-libp2p-tor-transport](github.com/berty/go-libp2p-tor-transport)
This allows to more easly implements a custom Backend allowing to do the usual instead of copy pasting the backend interface :
```go
var _ madns.Backend = (*customTorBackend)(nil)
```