### PR TITLE
refactor Resolver to support custom per-TLD resolvers

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,31 @@
+package madns
+
+import (
+	"context"
+	"net"
+)
+
+type MockResolver struct {
+	IP  map[string][]net.IPAddr
+	TXT map[string][]string
+}
+
+var _ BasicResolver = (*MockResolver)(nil)
+
+func (r *MockResolver) LookupIPAddr(ctx context.Context, name string) ([]net.IPAddr, error) {
+	results, ok := r.IP[name]
+	if ok {
+		return results, nil
+	} else {
+		return []net.IPAddr{}, nil
+	}
+}
+
+func (r *MockResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	results, ok := r.TXT[name]
+	if ok {
+		return results, nil
+	} else {
+		return []string{}, nil
+	}
+}

--- a/resolve.go
+++ b/resolve.go
@@ -55,7 +55,9 @@ func WithDefaultResolver(def BasicResolver) Option {
 	}
 }
 
-// WithTLDResolver specifies a custom resolver for a domain/TLD.
+// WithDomainResolver specifies a custom resolver for a domain/TLD.
+// Custom resolver selection matches domains left to right, with more specific resolvers
+// superseding generic ones.
 func WithDomainResolver(domain string, rslv BasicResolver) Option {
 	return func(r *Resolver) error {
 		if r.custom == nil {
@@ -67,6 +69,9 @@ func WithDomainResolver(domain string, rslv BasicResolver) Option {
 }
 
 func (r *Resolver) getResolver(domain string) BasicResolver {
+	// we match left-to-right, with more specific resolvers superseding generic ones.
+	// So for a domain a.b.c, we will try a.b,c, b.c, c, and fallback to the default if
+	// there is no match
 	rslv, ok := r.custom[domain]
 	if ok {
 		return rslv

--- a/resolve.go
+++ b/resolve.go
@@ -72,7 +72,7 @@ func (r *Resolver) getResolver(domain string) BasicResolver {
 		return rslv
 	}
 
-	for i := strings.Index(domain, "."); i != -1; i = strings.Index(domain, ",") {
+	for i := strings.Index(domain, "."); i != -1; i = strings.Index(domain, ".") {
 		domain = domain[i+1:]
 		rslv, ok = r.custom[domain]
 		if ok {

--- a/resolve.go
+++ b/resolve.go
@@ -58,6 +58,9 @@ func WithDefaultResolver(def BasicResolver) Option {
 // WithTLDResolver specifies a custom resolver for a domain/TLD.
 func WithDomainResolver(domain string, rslv BasicResolver) Option {
 	return func(r *Resolver) error {
+		if r.custom == nil {
+			r.custom = make(map[string]BasicResolver)
+		}
 		r.custom[domain] = rslv
 		return nil
 	}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -242,6 +242,7 @@ func TestCustomResolver(t *testing.T) {
 	ip3 := net.IPAddr{IP: net.ParseIP("3.4.5.6")}
 	ip4 := net.IPAddr{IP: net.ParseIP("4.5.6.8")}
 	ip5 := net.IPAddr{IP: net.ParseIP("5.6.8.9")}
+	ip6 := net.IPAddr{IP: net.ParseIP("6.8.9.10")}
 	def := &MockResolver{
 		IP: map[string][]net.IPAddr{
 			"example.com": []net.IPAddr{ip1},
@@ -251,6 +252,7 @@ func TestCustomResolver(t *testing.T) {
 		IP: map[string][]net.IPAddr{
 			"custom.test":         []net.IPAddr{ip2},
 			"another.custom.test": []net.IPAddr{ip3},
+			"more.custom.test":    []net.IPAddr{ip6},
 		},
 	}
 	custom2 := &MockResolver{

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -29,7 +29,7 @@ var txtd = "dnsaddr=" + txtmd.String()
 var txte = "dnsaddr=" + txtme.String()
 
 func makeResolver() *Resolver {
-	mock := &MockBackend{
+	mock := &MockResolver{
 		IP: map[string][]net.IPAddr{
 			"example.com": []net.IPAddr{ip4a, ip4b, ip6a, ip6b},
 		},
@@ -38,7 +38,7 @@ func makeResolver() *Resolver {
 			"_dnsaddr.matching.com": []string{txtc, txtd, txte, "not a dnsaddr", "dnsaddr=/foobar"},
 		},
 	}
-	resolver := &Resolver{Backend: mock}
+	resolver := &Resolver{def: mock}
 	return resolver
 }
 

--- a/util.go
+++ b/util.go
@@ -1,0 +1,57 @@
+package madns
+
+import (
+	"context"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func Matches(maddr ma.Multiaddr) (matches bool) {
+	ma.ForEach(maddr, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case DnsProtocol.Code, Dns4Protocol.Code, Dns6Protocol.Code, DnsaddrProtocol.Code:
+			matches = true
+		}
+		return !matches
+	})
+	return matches
+}
+
+func Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multiaddr, error) {
+	return DefaultResolver.Resolve(ctx, maddr)
+}
+
+// counts the number of components in the multiaddr
+func addrLen(maddr ma.Multiaddr) int {
+	length := 0
+	ma.ForEach(maddr, func(_ ma.Component) bool {
+		length++
+		return true
+	})
+	return length
+}
+
+// trims `offset` components from the beginning of the multiaddr.
+func offset(maddr ma.Multiaddr, offset int) ma.Multiaddr {
+	_, after := ma.SplitFunc(maddr, func(c ma.Component) bool {
+		if offset == 0 {
+			return true
+		}
+		offset--
+		return false
+	})
+	return after
+}
+
+// takes the cross product of two sets of multiaddrs
+//
+// assumes `a` is non-empty.
+func cross(a, b []ma.Multiaddr) []ma.Multiaddr {
+	res := make([]ma.Multiaddr, 0, len(a)*len(b))
+	for _, x := range a {
+		for _, y := range b {
+			res = append(res, x.Encapsulate(y))
+		}
+	}
+	return res
+}


### PR DESCRIPTION
See https://github.com/protocol/web3-dev-team/pull/42

We will have to implement our own DoH basic resolver, as the search for a viable library proved fruitless. But that should live in its own repo, it doesn't belong to `madns`.