### PR TITLE
fix!: Only resolve the first DNS-like component

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -109,6 +109,10 @@ func (r *Resolver) getResolver(domain string) BasicResolver {
 // Resolve resolves a DNS multiaddr. It will only resolve the first DNS component in the multiaddr.
 // If you need to resolve multiple DNS components, you may call this function again with each returned address.
 func (r *Resolver) Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multiaddr, error) {
+	if maddr == nil {
+		return nil, nil
+	}
+
 	// Find the next dns component.
 	preDNS, maddr := ma.SplitFunc(maddr, func(c ma.Component) bool {
 		switch c.Protocol().Code {

--- a/resolve.go
+++ b/resolve.go
@@ -16,8 +16,10 @@ var (
 	dnsProtocol     = ma.ProtocolWithCode(ma.P_DNS)
 )
 
-var ResolvableProtocols = []ma.Protocol{dnsaddrProtocol, dns4Protocol, dns6Protocol, dnsProtocol}
-var DefaultResolver = &Resolver{def: net.DefaultResolver}
+var (
+	ResolvableProtocols = []ma.Protocol{dnsaddrProtocol, dns4Protocol, dns6Protocol, dnsProtocol}
+	DefaultResolver     = &Resolver{def: net.DefaultResolver}
+)
 
 const dnsaddrTXTPrefix = "dnsaddr="
 
@@ -104,179 +106,162 @@ func (r *Resolver) getResolver(domain string) BasicResolver {
 	return r.def
 }
 
-// Resolve resolves a DNS multiaddr.
+// Resolve resolves a DNS multiaddr. It will only resolve the first DNS component in the multiaddr.
+// If you need to resolve multiple DNS components, you may call this function again with each returned address.
 func (r *Resolver) Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multiaddr, error) {
-	var results []ma.Multiaddr
-	for i := 0; maddr != nil; i++ {
-		var keep ma.Multiaddr
-
-		// Find the next dns component.
-		keep, maddr = ma.SplitFunc(maddr, func(c ma.Component) bool {
-			switch c.Protocol().Code {
-			case dnsProtocol.Code, dns4Protocol.Code, dns6Protocol.Code, dnsaddrProtocol.Code:
-				return true
-			default:
-				return false
-			}
-		})
-
-		// Keep everything before the dns component.
-		if keep != nil {
-			if len(results) == 0 {
-				results = []ma.Multiaddr{keep}
-			} else {
-				for i, r := range results {
-					results[i] = r.Encapsulate(keep)
-				}
-			}
-		}
-
-		// If the rest is empty, we've hit the end (there _was_ no dns component).
-		if maddr == nil {
-			break
-		}
-
-		// split off the dns component.
-		var resolve *ma.Component
-		resolve, maddr = ma.SplitFirst(maddr)
-
-		proto := resolve.Protocol()
-		value := resolve.Value()
-		rslv := r.getResolver(value)
-
-		// resolve the dns component
-		var resolved []ma.Multiaddr
-		switch proto.Code {
-		case dns4Protocol.Code, dns6Protocol.Code, dnsProtocol.Code:
-			// The dns, dns4, and dns6 resolver simply resolves each
-			// dns* component into an ipv4/ipv6 address.
-
-			v4only := proto.Code == dns4Protocol.Code
-			v6only := proto.Code == dns6Protocol.Code
-
-			// XXX: Unfortunately, go does a pretty terrible job of
-			// differentiating between IPv6 and IPv4. A v4-in-v6
-			// AAAA record will _look_ like an A record to us and
-			// there's nothing we can do about that.
-			records, err := rslv.LookupIPAddr(ctx, value)
-			if err != nil {
-				return nil, err
-			}
-
-			// Convert each DNS record into a multiaddr. If the
-			// protocol is dns4, throw away any IPv6 addresses. If
-			// the protocol is dns6, throw away any IPv4 addresses.
-
-			for _, r := range records {
-				var (
-					rmaddr ma.Multiaddr
-					err    error
-				)
-				ip4 := r.IP.To4()
-				if ip4 == nil {
-					if v4only {
-						continue
-					}
-					rmaddr, err = ma.NewMultiaddr("/ip6/" + r.IP.String())
-				} else {
-					if v6only {
-						continue
-					}
-					rmaddr, err = ma.NewMultiaddr("/ip4/" + ip4.String())
-				}
-				if err != nil {
-					return nil, err
-				}
-				resolved = append(resolved, rmaddr)
-			}
-		case dnsaddrProtocol.Code:
-			// The dnsaddr resolver is a bit more complicated. We:
-			//
-			// 1. Lookup the dnsaddr txt record on _dnsaddr.DOMAIN.TLD
-			// 2. Take everything _after_ the `/dnsaddr/DOMAIN.TLD`
-			//    part of the multiaddr.
-			// 3. Find the dnsaddr records (if any) with suffixes
-			//    matching the result of step 2.
-
-			// First, lookup the TXT record
-			records, err := rslv.LookupTXT(ctx, "_dnsaddr."+value)
-			if err != nil {
-				return nil, err
-			}
-
-			// Then, calculate the length of the suffix we're
-			// looking for.
-			length := 0
-			if maddr != nil {
-				length = addrLen(maddr)
-			}
-
-			for _, r := range records {
-				// Ignore non dnsaddr TXT records.
-				if !strings.HasPrefix(r, dnsaddrTXTPrefix) {
-					continue
-				}
-
-				// Extract and decode the multiaddr.
-				rmaddr, err := ma.NewMultiaddr(r[len(dnsaddrTXTPrefix):])
-				if err != nil {
-					// discard multiaddrs we don't understand.
-					// XXX: Is this right? It's the best we
-					// can do for now, really.
-					continue
-				}
-
-				// If we have a suffix to match on.
-				if maddr != nil {
-					// Make sure the new address is at least
-					// as long as the suffix we're looking
-					// for.
-					rmlen := addrLen(rmaddr)
-					if rmlen < length {
-						// not long enough.
-						continue
-					}
-
-					// Matches everything after the /dnsaddr/... with the end of the
-					// dnsaddr record:
-					//
-					// v----------rmlen-----------------v
-					// /ip4/1.2.3.4/tcp/1234/p2p/QmFoobar
-					//                      /p2p/QmFoobar
-					// ^--(rmlen - length)--^---length--^
-					if !maddr.Equal(offset(rmaddr, rmlen-length)) {
-						continue
-					}
-				}
-
-				resolved = append(resolved, rmaddr)
-			}
-
-			// consumes the rest of the multiaddr as part of the "match" process.
-			maddr = nil
+	// Find the next dns component.
+	preDNS, maddr := ma.SplitFunc(maddr, func(c ma.Component) bool {
+		switch c.Protocol().Code {
+		case dnsProtocol.Code, dns4Protocol.Code, dns6Protocol.Code, dnsaddrProtocol.Code:
+			return true
 		default:
-			panic("unreachable")
+			return false
+		}
+	})
+
+	// If the rest is empty, we've hit the end (there _was_ no dns component).
+	if maddr == nil {
+		return []ma.Multiaddr{preDNS}, nil
+	}
+
+	// split off the dns component.
+	resolve, postDNS := ma.SplitFirst(maddr)
+
+	proto := resolve.Protocol()
+	value := resolve.Value()
+	rslv := r.getResolver(value)
+
+	// resolve the dns component
+	var resolved []ma.Multiaddr
+	switch proto.Code {
+	case dns4Protocol.Code, dns6Protocol.Code, dnsProtocol.Code:
+		// The dns, dns4, and dns6 resolver simply resolves each
+		// dns* component into an ipv4/ipv6 address.
+
+		v4only := proto.Code == dns4Protocol.Code
+		v6only := proto.Code == dns6Protocol.Code
+
+		// XXX: Unfortunately, go does a pretty terrible job of
+		// differentiating between IPv6 and IPv4. A v4-in-v6
+		// AAAA record will _look_ like an A record to us and
+		// there's nothing we can do about that.
+		records, err := rslv.LookupIPAddr(ctx, value)
+		if err != nil {
+			return nil, err
 		}
 
-		if len(resolved) == 0 {
-			return nil, nil
-		} else if len(results) == 0 {
-			results = resolved
-		} else {
-			// We take the cross product here as we don't have any
-			// better way to represent "ORs" in multiaddrs. For
-			// example, `/dns/foo.com/p2p-circuit/dns/bar.com` could
-			// resolve to:
-			//
-			// * /ip4/1.1.1.1/p2p-circuit/ip4/2.1.1.1
-			// * /ip4/1.1.1.1/p2p-circuit/ip4/2.1.1.2
-			// * /ip4/1.1.1.2/p2p-circuit/ip4/2.1.1.1
-			// * /ip4/1.1.1.2/p2p-circuit/ip4/2.1.1.2
-			results = cross(results, resolved)
+		// Convert each DNS record into a multiaddr. If the
+		// protocol is dns4, throw away any IPv6 addresses. If
+		// the protocol is dns6, throw away any IPv4 addresses.
+
+		for _, r := range records {
+			var (
+				rmaddr ma.Multiaddr
+				err    error
+			)
+			ip4 := r.IP.To4()
+			if ip4 == nil {
+				if v4only {
+					continue
+				}
+				rmaddr, err = ma.NewMultiaddr("/ip6/" + r.IP.String())
+			} else {
+				if v6only {
+					continue
+				}
+				rmaddr, err = ma.NewMultiaddr("/ip4/" + ip4.String())
+			}
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, rmaddr)
+		}
+	case dnsaddrProtocol.Code:
+		// The dnsaddr resolver is a bit more complicated. We:
+		//
+		// 1. Lookup the dnsaddr txt record on _dnsaddr.DOMAIN.TLD
+		// 2. Take everything _after_ the `/dnsaddr/DOMAIN.TLD`
+		//    part of the multiaddr.
+		// 3. Find the dnsaddr records (if any) with suffixes
+		//    matching the result of step 2.
+
+		// First, lookup the TXT record
+		records, err := rslv.LookupTXT(ctx, "_dnsaddr."+value)
+		if err != nil {
+			return nil, err
+		}
+
+		// Then, calculate the length of the suffix we're
+		// looking for.
+		length := 0
+		if postDNS != nil {
+			length = addrLen(postDNS)
+		}
+
+		for _, r := range records {
+			// Ignore non dnsaddr TXT records.
+			if !strings.HasPrefix(r, dnsaddrTXTPrefix) {
+				continue
+			}
+
+			// Extract and decode the multiaddr.
+			rmaddr, err := ma.NewMultiaddr(r[len(dnsaddrTXTPrefix):])
+			if err != nil {
+				// discard multiaddrs we don't understand.
+				// XXX: Is this right? It's the best we
+				// can do for now, really.
+				continue
+			}
+
+			// If we have a suffix to match on.
+			if postDNS != nil {
+				// Make sure the new address is at least
+				// as long as the suffix we're looking
+				// for.
+				rmlen := addrLen(rmaddr)
+				if rmlen < length {
+					// not long enough.
+					continue
+				}
+
+				// Matches everything after the /dnsaddr/... with the end of the
+				// dnsaddr record:
+				//
+				// v----------rmlen-----------------v
+				// /ip4/1.2.3.4/tcp/1234/p2p/QmFoobar
+				//                      /p2p/QmFoobar
+				// ^--(rmlen - length)--^---length--^
+				if !postDNS.Equal(offset(rmaddr, rmlen-length)) {
+					continue
+				}
+			}
+
+			// remove the suffix from the multiaddr, we'll add it back at the end.
+			if postDNS != nil {
+				rmaddr = rmaddr.Decapsulate(postDNS)
+			}
+			resolved = append(resolved, rmaddr)
+		}
+	default:
+		panic("unreachable")
+	}
+
+	if len(resolved) == 0 {
+		return nil, nil
+	}
+
+	if preDNS != nil {
+		for i, m := range resolved {
+			resolved[i] = preDNS.Encapsulate(m)
+		}
+	}
+	if postDNS != nil {
+		for i, m := range resolved {
+			resolved[i] = m.Encapsulate(postDNS)
 		}
 	}
 
-	return results, nil
+	return resolved, nil
 }
 
 func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error) {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -239,6 +239,19 @@ func TestEmptyResult(t *testing.T) {
 	}
 }
 
+func TestNil(t *testing.T) {
+	ctx := context.Background()
+	resolver := makeResolver()
+
+	addrs, err := resolver.Resolve(ctx, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(addrs) > 0 {
+		t.Fatalf("expected [], got %+v", addrs)
+	}
+}
+
 func TestDnsaddrMatching(t *testing.T) {
 	ctx := context.Background()
 	resolver := makeResolver()

--- a/util.go
+++ b/util.go
@@ -42,16 +42,3 @@ func offset(maddr ma.Multiaddr, offset int) ma.Multiaddr {
 	})
 	return after
 }
-
-// takes the cross product of two sets of multiaddrs
-//
-// assumes `a` is non-empty.
-func cross(a, b []ma.Multiaddr) []ma.Multiaddr {
-	res := make([]ma.Multiaddr, 0, len(a)*len(b))
-	for _, x := range a {
-		for _, y := range b {
-			res = append(res, x.Encapsulate(y))
-		}
-	}
-	return res
-}


### PR DESCRIPTION
As far as I know, the ability to resolve multiple DNS addresses isn't used. This removes that ability for the simpler approach of just resolving the first DNS component in the multiaddr

BREAKING CHANGE: Previously Resolve would resolve all DNS components in a multiaddr. Now it will only resolve the first one. Users may iteratively call Resolve to get the old behavior. See the tests for an example.