### PR TITLE
feat: static resolution of p2p-forge domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/multiformats/go-multiaddr-dns
 
 require (
+	github.com/ipfs/go-cid v0.0.7
 	github.com/miekg/dns v1.1.41
 	github.com/multiformats/go-multiaddr v0.13.0
+	github.com/multiformats/go-multicodec v0.9.2
 )
 
 require (
-	github.com/ipfs/go-cid v0.0.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/multiformats/go-multiaddr v0.13.0/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamG
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivncJHmHnnd87g=
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=
+github.com/multiformats/go-multicodec v0.9.2 h1:YrlXCuqxjqm3bXl+vBq5LKz5pz4mvAsugdqy78k0pXQ=
+github.com/multiformats/go-multicodec v0.9.2/go.mod h1:LLWNMtyV5ithSBUo3vFIMaeDy+h3EbkMTek1m+Fybbo=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7BFvVU9RSh+U=
 github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=

--- a/resolve.go
+++ b/resolve.go
@@ -278,6 +278,12 @@ func (r *Resolver) Resolve(ctx context.Context, maddr ma.Multiaddr) ([]ma.Multia
 }
 
 func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAddr, error) {
+	if parts := parseP2PForgeDomain(domain); parts != nil {
+		if addrs, err := r.resolveP2PForge(ctx, domain, parts); err == nil {
+			return addrs, nil
+		}
+		// Fallback to normal resolver if synthetic offline resolution fails
+	}
 	return r.getResolver(domain).LookupIPAddr(ctx, domain)
 }
 

--- a/resolve_static.go
+++ b/resolve_static.go
@@ -1,0 +1,136 @@
+package madns
+
+// This file contains performance optimizations where well-known DNS label conventions
+// are resolved statically to avoid unnecessary network I/O.
+//
+// Currently supports:
+//   - p2p-forge protocol domains (deterministic IP address resolution): https://github.com/ipshipyard/p2p-forge
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+)
+
+const minLibp2pPeerIDLength = 42 // Conservative minimum per https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md
+
+// minP2PForgeDomain is the minimum possible length for a valid p2p-forge domain
+// Format: <ip>.<peerID>.<suffix>
+// Shortest IPv4: "0-0-0-0" (7 chars), shortest peerID: 42 chars, shortest suffix: "a" (1 char), dots: 2
+const minP2PForgeDomain = 7 + 1 + minLibp2pPeerIDLength + 1 + 1 // 52 characters
+
+// parseP2PForgeDomain checks if a domain follows the p2p-forge pattern
+// Format: <encoded-ip>.<peerID>.<suffix>
+// Returns the DNS labels if valid, nil otherwise
+func parseP2PForgeDomain(domain string) []string {
+	// Quick length check to avoid splitting obviously too-short domains
+	if len(domain) < minP2PForgeDomain {
+		return nil
+	}
+
+	parts := strings.Split(domain, ".")
+	if len(parts) < 3 { // need at least <ip>.<peerID>.<suffix>
+		return nil
+	}
+
+	// Check if the second part (index 1) looks like a libp2p peer ID
+	peerID := parts[1]
+	if !isLibp2pPeerID(peerID) {
+		return nil
+	}
+
+	return parts
+}
+
+// isLibp2pPeerID checks if a string is a valid libp2p peer ID
+// by parsing it as a CID and verifying it uses the libp2p-key codec
+func isLibp2pPeerID(s string) bool {
+	// Only attempt CID parsing if string is long enough to be a valid base36 libp2p peer ID
+	if len(s) < minLibp2pPeerIDLength {
+		return false
+	}
+
+	c, err := cid.Decode(s)
+	if err != nil {
+		return false
+	}
+
+	// Check if the CID uses the libp2p-key codec
+	return c.Type() == uint64(multicodec.Libp2pKey)
+}
+
+// resolveP2PForge handles p2p-forge domains that encode IP addresses
+// according to the p2p-forge protocol specification via synthetic offline resolution.
+//
+// Domain format: <encoded-ip>.<base36-peerID>.<suffix>
+//
+// See: https://github.com/ipshipyard/p2p-forge?tab=readme-ov-file#handled-dns-records
+func (r *Resolver) resolveP2PForge(ctx context.Context, domain string, parts []string) ([]net.IPAddr, error) {
+	// The first part is the encoded IP address
+	encodedIP := parts[0]
+
+	// Try IPv6 first (as per spec), then IPv4
+	if ip := decodeIPv6(encodedIP); ip != nil {
+		return []net.IPAddr{{IP: ip}}, nil
+	}
+
+	if ip := decodeIPv4(encodedIP); ip != nil {
+		return []net.IPAddr{{IP: ip}}, nil
+	}
+
+	return nil, &net.DNSError{
+		Err:    "invalid IP encoding in p2p-forge domain",
+		Name:   domain,
+		Server: "",
+	}
+}
+
+// decodeIPv4 converts hyphens back to dots for IPv4 addresses
+// Example: 1-2-3-4 → 1.2.3.4
+func decodeIPv4(encoded string) net.IP {
+	// Convert hyphens back to dots
+	ipStr := strings.ReplaceAll(encoded, "-", ".")
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return nil
+	}
+	// Ensure it's actually an IPv4 address
+	if ip.To4() == nil {
+		return nil
+	}
+	return ip
+}
+
+// decodeIPv6 converts encoded IPv6 addresses back to standard format
+// Handles multiple encoding rules:
+// 1. Standard: A-B-C-D-1-2-3-4 → A:B:C:D:1:2:3:4
+// 2. Condensed: A--C-D → A::C:D
+// 3. Leading zeros: 0--B-C-D → ::B:C:D
+// 4. Trailing zeros: 1--0 → 1::
+func decodeIPv6(encoded string) net.IP {
+	// Handle RFC 1123 compliance: replace leading/trailing 0 with empty string
+	if strings.HasPrefix(encoded, "0--") {
+		encoded = strings.TrimPrefix(encoded, "0")
+	}
+	if strings.HasSuffix(encoded, "--0") {
+		encoded = strings.TrimSuffix(encoded, "0")
+	}
+
+	// Replace -- with ::
+	ipStr := strings.ReplaceAll(encoded, "--", "::")
+	// Replace remaining hyphens with colons
+	ipStr = strings.ReplaceAll(ipStr, "-", ":")
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return nil
+	}
+	// Ensure it's actually an IPv6 address
+	if ip.To4() != nil {
+		return nil
+	}
+	return ip
+}

--- a/resolve_static_test.go
+++ b/resolve_static_test.go
@@ -1,0 +1,598 @@
+package madns
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestLibP2PDirectIPv4(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv4: 192.0.2.1 → 192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("192.0.2.1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6Standard(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 standard: 2001:db8::1 → 2001-db8-0-0-0-0-0-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8-0-0-0-0-0-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6Condensed(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 condensed: 2001:db8::1 → 2001-db8--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6LeadingZeros(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 leading zeros: ::1 → 0--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "0--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("::1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6TrailingZeros(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 trailing zeros: 2001:db8:: → 2001-db8--0.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8--0.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6TrailingZerosWithoutZero(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 trailing zeros without explicit zero: 2001:db8:: → 2001-db8--.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	// WARNING: DNS names ending with -- may not be valid according to RFC 1123
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8--.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6LeadingZerosWithoutZero(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 leading zeros without explicit zero: ::1 → --1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	// WARNING: DNS names starting with -- may not be valid according to RFC 1123
+	addrs, err := resolver.LookupIPAddr(ctx, "--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("::1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6CondensedWith0(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 condensed with 0: 2001:db8::1:2 → 2001-db8--1-2.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8--1-2.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::1:2")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6CondensedWithout0(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 condensed without 0: 2001:db8:85a3::8a2e → 2001-db8-85a3--8a2e.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8-85a3--8a2e.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8:85a3::8a2e")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6Priority(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 priority: IPv6 parsing is tried first, but may fail and fallback to IPv4
+	// Case: "10-0-0-1" - IPv6 "10:0:0:1::" is invalid, so falls back to IPv4 "10.0.0.1"
+	addrs, err := resolver.LookupIPAddr(ctx, "10-0-0-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("10.0.0.1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectIPv6PrioritySuccess(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test IPv6 priority success: valid IPv6 with hex digits (clearly not IPv4)
+	// Case: "2001-db8--a-b" - contains hex digits and ::, so IPv6 takes priority and succeeds
+	addrs, err := resolver.LookupIPAddr(ctx, "2001-db8--a-b.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("2001:db8::a:b")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestLibP2PDirectInvalidFormat(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test invalid format (no peer ID) - this should NOT match p2p-forge pattern and fallback to normal DNS
+	// Since MockResolver returns empty results (not errors), this will return empty results
+	addrs, err := resolver.LookupIPAddr(ctx, "192-0-2-1.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 0 {
+		t.Fatalf("Expected 0 addresses, got %d", len(addrs))
+	}
+
+	// Test invalid IP encoding - this should match p2p-forge pattern but fail IP decoding, then fallback to normal DNS
+	addrs, err = resolver.LookupIPAddr(ctx, "invalid-ip.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 0 {
+		t.Fatalf("Expected 0 addresses, got %d", len(addrs))
+	}
+}
+
+func TestLibP2PDirectFallback(t *testing.T) {
+	// Test fallback to normal DNS resolution
+	mock := &MockResolver{
+		IP: map[string][]net.IPAddr{
+			"fallback.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct": {
+				{IP: net.ParseIP("192.0.2.1")},
+			},
+		},
+	}
+	resolver := &Resolver{def: mock}
+	ctx := context.Background()
+
+	// This should fail synthetic resolution and fallback to normal DNS
+	addrs, err := resolver.LookupIPAddr(ctx, "fallback.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct")
+	if err != nil {
+		t.Fatalf("Expected no error with fallback, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("192.0.2.1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestP2PForgeCustomSuffix(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	// Test with custom suffix: .example.com
+	addrs, err := resolver.LookupIPAddr(ctx, "192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.example.com")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("Expected 1 address, got %d", len(addrs))
+	}
+	expected := net.ParseIP("192.0.2.1")
+	if !addrs[0].IP.Equal(expected) {
+		t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+	}
+}
+
+func TestP2PForgeMultipleSuffixes(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		domain string
+		ip     string
+	}{
+		{
+			name:   "custom.direct with base36 CIDv1",
+			domain: "2001-db8--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.custom.direct",
+			ip:     "2001:db8::1",
+		},
+		{
+			name:   "p2p.local with base36 CIDv1",
+			domain: "fe80--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.p2p.local",
+			ip:     "fe80::1",
+		},
+		{
+			name:   "peer.example.org with base36 CIDv1",
+			domain: "203-0-113-42.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.peer.example.org",
+			ip:     "203.0.113.42",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			addrs, err := resolver.LookupIPAddr(ctx, test.domain)
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if len(addrs) != 1 {
+				t.Fatalf("Expected 1 address, got %d", len(addrs))
+			}
+			expected := net.ParseIP(test.ip)
+			if !addrs[0].IP.Equal(expected) {
+				t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+			}
+		})
+	}
+}
+
+func TestLibp2pPeerIDValidation(t *testing.T) {
+	tests := []struct {
+		peerID   string
+		expected bool
+		desc     string
+	}{
+		{
+			peerID:   "k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r",
+			expected: true,
+			desc:     "valid base36 CIDv1 (Ed25519)",
+		},
+		{
+			peerID:   "k2k4r8oao3a13ig746677ovbb1s6hnvgksy42n2u8vo0o0m3xogyxhju",
+			expected: true,
+			desc:     "valid base36 CIDv1 (RSA)",
+		},
+		{
+			peerID:   "QmTzQ1JRkWErjk39mryYw2WVaphAZNAREyMchXzYQ59eTR",
+			expected: false,
+			desc:     "base58 CIDv0 not supported in DNS",
+		},
+		{
+			peerID:   "12D3KooWEy2U7rNW8sbEF8dz2vDj5fFzVWfgBsAj7nxNqvRxp1FR",
+			expected: false,
+			desc:     "base58 CIDv1 not supported in DNS",
+		},
+		{
+			peerID:   "kshort",
+			expected: false,
+			desc:     "too short",
+		},
+		{
+			peerID:   "k51invalid",
+			expected: false,
+			desc:     "wrong base36 prefix",
+		},
+		{
+			peerID:   "regular-string",
+			expected: false,
+			desc:     "not a peer ID",
+		},
+		{
+			peerID:   "k51qzi5uqu5INVALID",
+			expected: false,
+			desc:     "invalid base36 characters (uppercase)",
+		},
+		{
+			peerID:   "k2jmtxw8rjh1z69c6not3wtdxb0u3urbzhyll1t9jg6ox26dhi5sfi1m",
+			expected: false,
+			desc:     "valid CID but wrong codec (not libp2p-key)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := isLibp2pPeerID(test.peerID)
+			if result != test.expected {
+				t.Fatalf("Expected %v for %s, got %v", test.expected, test.peerID, result)
+			}
+		})
+	}
+}
+
+func TestP2PForgeDomainParsing(t *testing.T) {
+	tests := []struct {
+		domain   string
+		expected bool
+		desc     string
+	}{
+		{
+			domain:   "192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: true,
+			desc:     "valid p2p-forge pattern with base36 CIDv1",
+		},
+		{
+			domain:   "192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.example.com",
+			expected: true,
+			desc:     "valid p2p-forge pattern with base36 CIDv1",
+		},
+		{
+			domain:   "example.com",
+			expected: false,
+			desc:     "regular domain",
+		},
+		{
+			domain:   "192-0-2-1.regular-subdomain.example.com",
+			expected: false,
+			desc:     "no peer ID",
+		},
+		{
+			domain:   "192-0-2-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r",
+			expected: false,
+			desc:     "insufficient parts (no suffix)",
+		},
+		{
+			domain:   "example.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.com",
+			expected: true,
+			desc:     "peer ID in correct position (but weird IP encoding)",
+		},
+		{
+			domain:   "192-0-2-1.subdomain.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.com",
+			expected: false,
+			desc:     "peer ID in wrong position (third instead of second)",
+		},
+		{
+			domain:   "192-0-2-1.kshort.example.com",
+			expected: false,
+			desc:     "invalid peer ID (too short)",
+		},
+		{
+			domain:   "192-0-2-1.k51invalid.example.com",
+			expected: false,
+			desc:     "invalid peer ID (wrong base36 prefix)",
+		},
+		{
+			domain:   "192-0-2-1.QmInvalid.example.com",
+			expected: false,
+			desc:     "invalid peer ID (base58 not supported in DNS)",
+		},
+		{
+			domain:   "192-0-2-1.k2jmtxw8rjh1z69c6not3wtdxb0u3urbzhyll1t9jg6ox26dhi5sfi1m.example.com",
+			expected: false,
+			desc:     "valid CID but wrong codec (not libp2p-key)",
+		},
+		{
+			domain:   "short.domain",
+			expected: false,
+			desc:     "too short domain (length optimization)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := parseP2PForgeDomain(test.domain)
+			isValid := result != nil
+			if isValid != test.expected {
+				t.Fatalf("Expected %v for %s, got %v", test.expected, test.domain, isValid)
+			}
+		})
+	}
+}
+
+func TestLibP2PDirectComplexCases(t *testing.T) {
+	resolver := &Resolver{def: &MockResolver{}}
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "IPv4 TEST-NET-1",
+			domain:   "192-0-2-255.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "192.0.2.255",
+		},
+		{
+			name:     "IPv4 TEST-NET-2",
+			domain:   "198-51-100-1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "198.51.100.1",
+		},
+		{
+			name:     "IPv4 TEST-NET-3",
+			domain:   "203-0-113-42.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "203.0.113.42",
+		},
+		{
+			name:     "IPv6 RFC3849 doc prefix",
+			domain:   "2001-db8-85a3-0000-0000-8a2e-0370-7334.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "2001:db8:85a3::8a2e:370:7334",
+		},
+		{
+			name:     "IPv6 RFC3849 condensed",
+			domain:   "2001-db8--8a2e-370-7334.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "2001:db8::8a2e:370:7334",
+		},
+		{
+			name:     "IPv6 link-local",
+			domain:   "fe80--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "fe80::1",
+		},
+		{
+			name:     "IPv6 loopback",
+			domain:   "0--1.k51qzi5uqu5dj2c294cab64yiq2ri684kc5sr9odfhoo84osl4resldwfy8u5r.libp2p.direct",
+			expected: "::1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			addrs, err := resolver.LookupIPAddr(ctx, test.domain)
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if len(addrs) != 1 {
+				t.Fatalf("Expected 1 address, got %d", len(addrs))
+			}
+			expected := net.ParseIP(test.expected)
+			if !addrs[0].IP.Equal(expected) {
+				t.Fatalf("Expected %s, got %s", expected, addrs[0].IP)
+			}
+		})
+	}
+}
+
+func TestDecodeIPv4(t *testing.T) {
+	tests := []struct {
+		encoded  string
+		expected string
+		valid    bool
+	}{
+		{"192-0-2-1", "192.0.2.1", true},
+		{"198-51-100-1", "198.51.100.1", true},
+		{"203-0-113-42", "203.0.113.42", true},
+		{"0-0-0-0", "0.0.0.0", true},
+		{"invalid", "", false},
+		{"192-0-2", "", false},
+		{"192-0-2-1-5", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.encoded, func(t *testing.T) {
+			result := decodeIPv4(test.encoded)
+			if test.valid {
+				if result == nil {
+					t.Fatalf("Expected valid IP, got nil")
+				}
+				expected := net.ParseIP(test.expected)
+				if !result.Equal(expected) {
+					t.Fatalf("Expected %s, got %s", expected, result)
+				}
+			} else {
+				if result != nil {
+					t.Fatalf("Expected nil, got %s", result)
+				}
+			}
+		})
+	}
+}
+
+func TestDecodeIPv6(t *testing.T) {
+	tests := []struct {
+		encoded  string
+		expected string
+		valid    bool
+	}{
+		{"2001-db8--1", "2001:db8::1", true},
+		{"2001-db8-85a3--8a2e", "2001:db8:85a3::8a2e", true},
+		{"0--1", "::1", true},
+		{"--1", "::1", true},
+		{"2001-db8--0", "2001:db8::", true},
+		{"2001-db8--", "2001:db8::", true},
+		{"fe80-0-0-0-0-0-0-1", "fe80::1", true},
+		{"2001-0db8-85a3-0000-0000-8a2e-0370-7334", "2001:db8:85a3::8a2e:370:7334", true},
+		{"invalid", "", false},
+		{"192-0-2-1", "", false}, // This should be treated as IPv4, not IPv6
+	}
+
+	for _, test := range tests {
+		t.Run(test.encoded, func(t *testing.T) {
+			result := decodeIPv6(test.encoded)
+			if test.valid {
+				if result == nil {
+					t.Fatalf("Expected valid IP, got nil")
+				}
+				expected := net.ParseIP(test.expected)
+				if !result.Equal(expected) {
+					t.Fatalf("Expected %s, got %s", expected, result)
+				}
+			} else {
+				if result != nil {
+					t.Fatalf("Expected nil, got %s", result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR aims to add support for static (deterministic) domains to reduce the number of DNS queries for A and AAAA a libp2p node needs to make. We can't avoid them in web browsers, but we can avoid them in non-browser contexts.

TLDR:

- Implement synthetic offline resolution for p2p-forge protocol ref. https://github.com/ipshipyard/p2p-forge#handled-dns-records
- :point_right:  Saves client from sending two DNS queries (A + AAAA) for each multiaddr with DNS name that follows [p2p-forge convention](https://github.com/ipshipyard/p2p-forge#handled-dns-records)
- This is not hardcoding `libp2p.direct`, it supports any domain suffix with valid libp2p peer IDs in second position
- This is backward and forward compatible: if domain turns out to be false-positive, it fallbacks to normal DNS resolver
- This should not impact perf, we avoid expensive parsing if DNS labels are too short

cc @sukunrt @aschmahmann 