### PR TITLE
feat: add LookupTXTWithTTL to Resolver

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"strings"
+	"time"
 
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -311,4 +312,29 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) ([]net.IPAdd
 
 func (r *Resolver) LookupTXT(ctx context.Context, txt string) ([]string, error) {
 	return r.getResolver(txt).LookupTXT(ctx, txt)
+}
+
+// TXTWithTTLResolver is an optional interface a [BasicResolver] may implement to
+// report the TTL of a TXT record set alongside its values. Resolvers backed by
+// a protocol that carries TTLs (such as DNS-over-HTTPS) can implement it; the
+// default OS resolver cannot.
+type TXTWithTTLResolver interface {
+	LookupTXTWithTTL(ctx context.Context, name string) (txt []string, ttl time.Duration, err error)
+}
+
+// a Resolver routes TXT-with-TTL lookups, so it satisfies the interface too
+var _ TXTWithTTLResolver = (*Resolver)(nil)
+
+// LookupTXTWithTTL resolves the TXT records for a domain and, when the matched
+// per-domain resolver implements [TXTWithTTLResolver], also returns their TTL.
+// Resolvers that cannot report a TTL (such as the default OS resolver) yield a
+// TTL of 0, meaning unknown.
+func (r *Resolver) LookupTXTWithTTL(ctx context.Context, domain string) ([]string, time.Duration, error) {
+	rslv := r.getResolver(domain)
+	if ttlRslv, ok := rslv.(TXTWithTTLResolver); ok {
+		return ttlRslv.LookupTXTWithTTL(ctx, domain)
+	}
+
+	txt, err := rslv.LookupTXT(ctx, domain)
+	return txt, 0, err
 }

--- a/resolve_ttl_test.go
+++ b/resolve_ttl_test.go
@@ -1,0 +1,61 @@
+package madns
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// mockTTLResolver is a MockResolver that also reports a fixed TTL for TXT lookups.
+type mockTTLResolver struct {
+	*MockResolver
+	ttl time.Duration
+}
+
+func (r *mockTTLResolver) LookupTXTWithTTL(ctx context.Context, name string) ([]string, time.Duration, error) {
+	txt, err := r.MockResolver.LookupTXT(ctx, name)
+	return txt, r.ttl, err
+}
+
+func TestLookupTXTWithTTL(t *testing.T) {
+	ctx := context.Background()
+
+	def := &MockResolver{TXT: map[string][]string{
+		"example.com": {"dnslink=/ipfs/bafkqaaa"},
+	}}
+	withTTL := &mockTTLResolver{
+		MockResolver: &MockResolver{TXT: map[string][]string{
+			"custom.test": {"dnslink=/ipfs/bafkqaaa"},
+		}},
+		ttl: 42 * time.Second,
+	}
+
+	rslv, err := NewResolver(
+		WithDefaultResolver(def),
+		WithDomainResolver("custom.test", withTTL),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the matched per-domain resolver supports TTL, so it is reported
+	txt, ttl, err := rslv.LookupTXTWithTTL(ctx, "custom.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txt) != 1 {
+		t.Fatalf("expected 1 TXT record, got %d", len(txt))
+	}
+	if ttl != 42*time.Second {
+		t.Fatalf("expected ttl 42s, got %s", ttl)
+	}
+
+	// the default resolver does not support TTL, so it is reported as unknown (0)
+	_, ttl, err = rslv.LookupTXTWithTTL(ctx, "example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 0 {
+		t.Fatalf("expected unknown ttl 0 for resolver without TTL support, got %s", ttl)
+	}
+}


### PR DESCRIPTION
## Problem

`Resolver.LookupTXT` routes to the matched per-domain resolver but returns only the record values, dropping any TTL. A resolver that knows the TTL (such as a DNS-over-HTTPS resolver) has no way to report it, so callers cannot tell how long a TXT record set is valid or when to re-resolve it. Correct caching and expiration needs that TTL for both kinds of TXT records this library resolves:

- **DNSADDR** ([`dnsaddr=`](https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md)): the TTL bounds how long a resolved multiaddr is valid. Multiaddrs increasingly carry rotating `/certhash/` segments (AutoTLS WebTransport / WebRTC-direct nodes, including libp2p bootstrappers). Without the TTL these cannot be cached or expired correctly, so a peer cannot reliably publish addresses whose certhash changes over time: stale certhashes linger and dials fail.
- **DNSLink** (`dnslink=`): the TTL lets an IPFS gateway set `Cache-Control: max-age=<ttl>` for `/ipns/<dnslink-host>` responses (see ipfs/boxo#329).

## Fix

- Add `TXTWithTTLResolver`, an optional interface a `BasicResolver` may implement to report the TTL of a TXT record set.
- Add `Resolver.LookupTXTWithTTL`, which routes to the matched per-domain resolver and returns its TTL when that resolver implements `TXTWithTTLResolver`. Resolvers without TTL support (such as the default OS resolver) report `0`, meaning unknown.
- `Resolver` itself implements `TXTWithTTLResolver`, so a `Resolver` used as a per-domain resolver routes TTL too.

`LookupTXT` and the `BasicResolver` interface are unchanged, so this is additive. A DoH resolver that implements `LookupTXTWithTTL` (libp2p/go-doh-resolver#33) flows its TTL through to consumers: libp2p address resolution for DNSADDR, and boxo's DNSLink resolution.